### PR TITLE
Add liblzma-dev to Debian instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the embedded (netboot) build see also "embedded/legal-info" for more informa
 Install the build dependencies:
 
 ```
-sudo apt install --no-install-recommends build-essential devscripts debhelper cmake git libarchive-dev libcurl4-gnutls-dev \
+sudo apt install --no-install-recommends build-essential devscripts debhelper cmake git libarchive-dev libcurl4-gnutls-dev liblzma-dev \
     qtbase5-dev qtbase5-dev-tools qtdeclarative5-dev libqt5svg5-dev qttools5-dev libgnutls28-dev \
     qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-templates2 qml-module-qtquick-window2 qml-module-qtgraphicaleffects
 ```


### PR DESCRIPTION
Turns out we actually require liblzma-dev, and without it we will fail to configure CMake with default options.

So let's add it to the readme.